### PR TITLE
Update parsing of storyboards

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1505,7 +1505,16 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         def get_storyboards(video_info):
             storyboards = []
-            spec = video_info.get('storyboard_spec', [])
+            
+            player_response = video_info.get('player_response', [])
+            if len(player_response) > 0 and isinstance(player_response[0], compat_str):
+                player_response = self._parse_json(
+                    player_response[0], video_id, fatal=False)
+                if player_response:
+                    spec = [player_response['storyboards']['playerStoryboardSpecRenderer']['spec']]
+
+            else:
+                spec = video_info.get('storyboard_spec', [])
 
             for s in spec:
                 s_parts = s.split('|')

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1542,7 +1542,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         self._downloader.report_warning('Unable to extract storyboard')
                         continue
 
-                    storyboards_url = base_url.replace('$L', compat_str(i)) + '?'
+                    storyboards_url = base_url.replace('$L', compat_str(i)) + '&'
                     for j in range(n_images):
                         url = storyboards_url.replace('$N', filename).replace('$M', compat_str(j)) + 'sigh=' + sigh
                         if j == n_images-1:


### PR DESCRIPTION
The format for getting storyboards seems to have changed. They are now available in the 'player_response' field.

I checked with master@rg3/youtube-dl that it works.